### PR TITLE
Add fix for Ubuntu 16.04 and ROS Kinetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pico_flexx_driver)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBT_USE_DOUBLE_PRECISION")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -march=native -DBT_USE_DOUBLE_PRECISION")
 # Unused warnings
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wuninitialized -Winit-self -Wunused-function -Wunused-label -Wunused-variable -Wunused-but-set-variable -Wunused-but-set-parameter")
 # Additional warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pico_flexx_driver)
 
+# Fix for 'pico_nodelet not found' error in Ubuntu 16.04 and ROS kinetic [03.06.2017]
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -march=native -DBT_USE_DOUBLE_PRECISION")
 # Unused warnings
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wuninitialized -Winit-self -Wunused-function -Wunused-label -Wunused-variable -Wunused-but-set-variable -Wunused-but-set-parameter")

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Confirmed working for:
 
 as of June 03, 2017
 
+*This is a temporary repo, maintainer seems to have dropped responsibility*
+
 ## Table of contents
 - [Description](#description)
 - [Dependencies](#dependencies)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 - [Thiemo Wiedemeyer](https://ai.uni-bremen.de/team/thiemo_wiedemeyer) <<wiedemeyer@cs.uni-bremen.de>>, [Institute for Artificial Intelligence](https://ai.uni-bremen.de/), University of Bremen
 
+## Status
+Confirmed working for:
+- Ubuntu 16.04.
+- Picoflexx driver v3.0.1.122
+- ROS Kinetic
+
+as of June 03, 2017
+
 ## Table of contents
 - [Description](#description)
 - [Dependencies](#dependencies)


### PR DESCRIPTION
Fix 'failed to load pico_flexx_nodelet' error in Ubuntu 16.04 and ROS Kinetic

Confirmed working as of June 3, 2017 with:
* libroyal SDK v3.1.0.122 
* Ubuntu 16.04.
* ROS Kinetic