### PR TITLE
Add mixed modes + miscellaneous fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ ELSE()
   MESSAGE(ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 ENDIF()
 
-set(CMAKE_MODULE_PATH   ${PROJECT_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH   ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
@@ -52,6 +52,7 @@ generate_dynamic_reconfigure_options(
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
+  CATKIN_DEPENDS nodelet roscpp rostime sensor_msgs std_msgs dynamic_reconfigure
 )
 
 ###########

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Bandwidth: 153.28 KB per message (@5 Hz: ~766 KB/s, @45 Hz: ~ 6897 KB/s)
 This is the distorted noise image. It is a 32-Bit float image where each pixel is a noise value of the corresponding depth pixel measured in meters.
 
 ##### `/pico_flexx/points`
-Bandwidth: 770 KB per message (@5 Hz: ~3850 KB/s, @45 Hz: ~ 34650 KB/s)
+Bandwidth: 720 KB per message (@5 Hz: ~3600 KB/s, @45 Hz: ~ 32400 KB/s)
 
 This is the point cloud created by the sensor. It contains 6 fields in the following order: X, Y, Z, Noise (float), Intensity (16-Bit), Gray (8-Bit).
 The 3D points themselves are undistorted, while the 2D coordinates of the points are distorted. The point cloud is organized, so that the each point belongs to the pixel with the same index in one of the other images.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ Some parameters can be reconfigured during runtime, for example with `rosrun rqt
 
 #### Topics
 
+When a mixed mode use case is selected, the second stream for all topics below
+is published under the `stream2` namespace (e.g.,
+`/pico_flexx/stream2/points`). In mixed mode, both a low-range, high-noise,
+high-frequency point cloud and a high-range, low-noise, low-frequency (5 Hz)
+point cloud are published. The 5 Hz point cloud in mixed mode only allows a
+maximum exposure time of 1300 microseconds, so it has slightly higher noise
+than the 5 Hz point cloud in single mode at 2000 microseconds.
+
 ##### `/pico_flexx/camera_info`
 Bandwidth: 0.37 KB per message (@5 Hz: ~2 KB/s, @45 Hz: ~ 17 KB/s)
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,17 @@ The launch file has the following parameters:
 
   Enable or disable automatic exposure.
 
+- `automatic_exposure_stream2` (default="true"):
+
+  Enable or disable automatic exposure for stream 2.
+
 - `exposure_time` (default="1000"):
 
   Exposure time. Only for manual exposure.
+
+- `exposure_time_stream2` (default="1000"):
+
+  Exposure time for stream 2. Only for manual exposure.
 
 - `max_noise` (default="0.07"):
 

--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ Some parameters can be reconfigured during runtime, for example with `rosrun rqt
 
   Choose from a list of use cases.
 
-- `exposure_mode`:
+- `exposure_mode`, `exposure_mode_stream2`:
 
   `AUTOMATIC` or `MANUAL`.
 
-- `exposure_time`:
+- `exposure_time`, `exposure_time_stream2`:
 
   Exposure time. Only for manual exposure.
 

--- a/cfg/pico_flexx_driver.cfg
+++ b/cfg/pico_flexx_driver.cfg
@@ -10,14 +10,16 @@ use_cases = gen.enum([ gen.const("MODE_9_5FPS_2000",  int_t, 0, "8+1, 5  FPS, ma
                        gen.const("MODE_9_15FPS_700",  int_t, 2, "8+1, 15 FPS, max exposure time  700 micro seconds"),
                        gen.const("MODE_9_25FPS_450",  int_t, 3, "8+1, 25 FPS, max exposure time  450 micro seconds"),
                        gen.const("MODE_5_35FPS_600",  int_t, 4, "4+1, 35 FPS, max exposure time  600 micro seconds"),
-                       gen.const("MODE_5_45FPS_500",  int_t, 5, "4+1, 45 FPS, max exposure time  500 micro seconds")
+                       gen.const("MODE_5_45FPS_500",  int_t, 5, "4+1, 45 FPS, max exposure time  500 micro seconds"),
+                       gen.const("MODE_MIXED_30_5",   int_t, 6, "Mixed mode: 30/5 FPS, max exposure time  300/1300 micro seconds"),
+                       gen.const("MODE_MIXED_50_5",   int_t, 7, "Mixed mode: 50/5 FPS, max exposure time  250/1000 micro seconds")
                      ], "possible use cases")
 
 exposure_modes = gen.enum([ gen.const("MANUAL", int_t, 0, "Manual exposure mode"),
                             gen.const("AUTOMATIC", int_t, 1, "Automatic exposure mode")
                           ], "Possible exposure modes")
 
-gen.add("use_case",       int_t,    0x01, "Use cases for the sensor", 0, 0, 5, edit_method=use_cases)
+gen.add("use_case",       int_t,    0x01, "Use cases for the sensor", 0, 0, 7, edit_method=use_cases)
 gen.add("exposure_mode",  int_t,    0x02, "Exposure mode for the sensor", 0, 0, 1, edit_method=exposure_modes)
 gen.add("exposure_time",  int_t,    0x04, "Exposure time", 1000, 1, 2000)
 gen.add("max_noise",      double_t, 0x08, "Max allowed noise", 0.07, 0.0, 0.1)

--- a/cfg/pico_flexx_driver.cfg
+++ b/cfg/pico_flexx_driver.cfg
@@ -19,10 +19,12 @@ exposure_modes = gen.enum([ gen.const("MANUAL", int_t, 0, "Manual exposure mode"
                             gen.const("AUTOMATIC", int_t, 1, "Automatic exposure mode")
                           ], "Possible exposure modes")
 
-gen.add("use_case",       int_t,    0x01, "Use cases for the sensor", 0, 0, 7, edit_method=use_cases)
-gen.add("exposure_mode",  int_t,    0x02, "Exposure mode for the sensor", 0, 0, 1, edit_method=exposure_modes)
-gen.add("exposure_time",  int_t,    0x04, "Exposure time", 1000, 1, 2000)
-gen.add("max_noise",      double_t, 0x08, "Max allowed noise", 0.07, 0.0, 0.1)
-gen.add("range_factor",   double_t, 0x10, "Range of factor times standard deviation arround mean", 2.0, 0.0, 7.0)
+gen.add("use_case",               int_t,    0x01, "Use cases for the sensor", 0, 0, 7, edit_method=use_cases)
+gen.add("exposure_mode",          int_t,    0x02, "Exposure mode for the sensor", 0, 0, 1, edit_method=exposure_modes)
+gen.add("exposure_mode_stream2",  int_t,    0x04, "Exposure mode for the sensor (stream 2)", 0, 0, 1, edit_method=exposure_modes)
+gen.add("exposure_time",          int_t,    0x08, "Exposure time", 1000, 1, 2000)
+gen.add("exposure_time_stream2",  int_t,    0x10, "Exposure time (stream 2)", 1000, 1, 2000)
+gen.add("max_noise",              double_t, 0x20, "Max allowed noise", 0.07, 0.0, 0.1)
+gen.add("range_factor",           double_t, 0x40, "Range of factor times standard deviation arround mean", 2.0, 0.0, 7.0)
 
 exit(gen.generate(PACKAGE, "pico_flexx_driver", "pico_flexx_driver"))

--- a/src/pico_flexx_driver.cpp
+++ b/src/pico_flexx_driver.cpp
@@ -747,8 +747,7 @@ private:
     }
     OUT_INFO("use case changed to: " FG_YELLOW << useCases[idx]);
 
-    std::string name;
-    useCases[idx].toStdString(name);
+    std::string name = royale::String::toStdString(useCases[idx]);
     size_t end = name.find("FPS");
     size_t start = name.rfind('_', end);
 

--- a/src/pico_flexx_driver.cpp
+++ b/src/pico_flexx_driver.cpp
@@ -347,6 +347,15 @@ public:
         return;
       }
       this->config.use_case = config.use_case;
+
+      // Need to explicitly set these parameters because of the following sequence of calls:
+      // - setUseCase() above causes the driver to change the exposure times
+      // - onNewExposure() is triggered, updates this->config
+      // - server.updateConfig() correctly sets the new params
+      // - execution returns here; without the following two lines, the values on the server
+      //   would be reset to the stale values in config on return from this function
+      config.exposure_time = this->config.exposure_time;
+      config.exposure_time_stream2 = this->config.exposure_time_stream2;
     }
 
     if(level & 0x02)

--- a/src/pico_flexx_driver.cpp
+++ b/src/pico_flexx_driver.cpp
@@ -748,8 +748,22 @@ private:
     OUT_INFO("use case changed to: " FG_YELLOW << useCases[idx]);
 
     std::string name = royale::String::toStdString(useCases[idx]);
-    size_t end = name.find("FPS");
-    size_t start = name.rfind('_', end);
+    size_t start, end;
+
+    // handle MODE_9_5FPS_2000 etc.
+    end = name.find("FPS");
+    start = name.rfind('_', end);
+    if (start != std::string::npos)
+      start += 1;
+
+    if(end == std::string::npos || start == std::string::npos)
+    {
+      // handle MODE_MIXED_30_5, MODE_MIXED_50_5
+      start = name.find("MIXED_");
+      if (start != std::string::npos)
+        start += 6;
+      end = name.find("_", start);
+    }
 
     if(end == std::string::npos || start == std::string::npos)
     {
@@ -759,7 +773,6 @@ private:
       lockTiming.unlock();
       return true;
     }
-    start += 1;
 
     std::string fpsString = name.substr(start, end - start);
     if(fpsString.find_first_not_of("0123456789") != std::string::npos)


### PR DESCRIPTION
This PR does the following (see the individual commits):

**Bug fixes:**

* *Only use 8 bits for UINT8, not 16:* This reduces the bytes per point to 19 instead of 20.
* *Fix "could not extract frames per second from operation mode" error message*
* *Correctly update exposure_time to actual values:* Without this, when changing the use case in rqt_reconfigure, the exposure time shortly jumped to the correct new values and then reverted to the old ones.


**New features:**

* *Add the new "mixed modes" available since libroyale 3.3.0:* When a "mixed mode" use case is selected, both a low-range, high-noise, high-frequency point cloud and a high-range, low-noise, low-frequency point cloud are published. The 5 Hz point cloud has higher noise than in a default "non-mixed" mode, but this is still extremely useful for some use cases.