### PR TITLE
Fix for dynamic reconfigure ns clash. Closes #13

### DIFF
--- a/src/pico_flexx_driver.cpp
+++ b/src/pico_flexx_driver.cpp
@@ -137,7 +137,7 @@ private:
 
 public:
   PicoFlexx(const ros::NodeHandle &nh = ros::NodeHandle(), const ros::NodeHandle &priv_nh = ros::NodeHandle("~"))
-    : royale::IDepthDataListener(), royale::IExposureListener2(), nh(nh), priv_nh(priv_nh), server(lockServer)
+    : royale::IDepthDataListener(), royale::IExposureListener2(), nh(nh), priv_nh(priv_nh), server(lockServer, priv_nh)
   {
     cbExposureTime.resize(2);
     running = false;


### PR DESCRIPTION
I'm floating this non-backwards compatible fix for #13. This is the cleanest solution, and feels right to me. It will change the namespace of the dynamic reconfigure server for anyone using this driver.

If you'd like a backwards compatible fix, I can initialize `server` inside the constructor after checking a flag as to whether it should be launched using the private nodehandle. Let me know. Since this package is always built by source, I wasn't sure if it was maintaining API compatibility yet.